### PR TITLE
docs: fix onDrop parameter names in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ const Component = () => {
   };
 
   const onTreeListSelected = (item) => {
-    console.log("choosed item =", item);
+    console.log("selected item =", item);
   };
 
-  const onDrop = (dragingNode, dragNode, drogType) => {
-    console.log("dragingNode:", dragingNode);
-    console.log("dragNode:", dragNode);
-    console.log("drogType:", drogType);
+  const onDrop = (draggingNode, dropNode, dropType) => {
+    console.log("draggingNode:", draggingNode);
+    console.log("dropNode:", dropNode);
+    console.log("dropType:", dropType);
   };
 
   return (


### PR DESCRIPTION
The `onDrop` callback example in the README had two typos that did not match the actual API:

- `dragingNode` → `draggingNode` (matches the TypeScript interface)
- `dragNode` → `dropNode` (matches the TypeScript interface)
- `drogType` → `dropType` (matches the TypeScript interface)
- `"choosed item"` → `"selected item"` in the `onSelected` example

No functional changes.